### PR TITLE
Allow objects

### DIFF
--- a/visualize.py
+++ b/visualize.py
@@ -8,12 +8,26 @@ from matplotlib.collections import PatchCollection
 
 import toolz
 
+import socket
+
+def get_global_shapepath():
+    host = socket.gethostname()
+    
+    if host.split('.')[-1] == 'brc':
+        return '/global/scratch/mdelgado/shapefiles/world-combo-new-nytimes/new_shapefile'
+    elif host == 'sacagawea':
+        return '/shares/gcp/climate/_spatial_data/world-combo-new-nytimes/new_shapefile'
+    else:
+        raise KeyError('hostname {} not recognized'.format(host))
 
 @toolz.memoize
 def prep_polygons(
-        shapepath='/shares/gcp/climate/_spatial_data/world-combo-new-nytimes/new_shapefile',
+        shapepath=None,
         projection='cyl',
         **kwargs):
+    
+    if shapepath is None:
+        shapepath = get_global_shapepath()
 
     m = Basemap(projection=projection, llcrnrlat=-90, urcrnrlat=90,\
             llcrnrlon=-180, urcrnrlon=180, resolution=None, **kwargs)


### PR DESCRIPTION
A couple changes, some API breaking, some not. Let me know if you feel strongly that this isn't the right way to go, but allowing users to provide DataArrays to construct_... functions is really helpful to me when using a notebook.

## API-breaking changes
* `impact.py:construct_covars` now accepts keyword arguments rather than a dictionary. The values can be either paths or DataArrays.
* `impact.py:construct_weather` now accepts keyword arguments rather than a dictionary. The values can be either paths or DataArrays. Metadata can no longer be passed in to fill the paths.

## Improvements that don't break the API
* visualize.py:plot_by_hierid now selects the correct shapefile on sacagawea or brc if none is provided by using ``socket.gethostname()``